### PR TITLE
Reference `shouldRegisterToParent` in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ children can have access to parent properties via the `composableParent` propert
 
 ```
 
+** By default, all children will be registered with their parent. If you'd like to customize which components are registered, override the `shouldRegisterToParent` method:**
+
+```js
+shouldRegisterToParent(parentComponent) {
+  const registeredChildren = parentComponent.getComposableChildren();
+  const existingChild = childComponents.findBy('headerName', this.get('headerName'));
+  return Ember.isNone(existingChild);
+}
+```
+
 
 ## Installation
 


### PR DESCRIPTION
Adds additional documentation about overriding `shouldRegisterToParent`.
